### PR TITLE
selected pytest as test framework, created two tests to begin testing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ local.properties
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/
 
 # Generated files
 .idea/**/contentModel.xml

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
+pytest-cov = "*"
 
 [packages]
 nltk = "*"

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest import mock
+from src.util.analyzer import normalize, tokenize
+
+
+@pytest.mark.parametrize('input_text, answer',
+                         [('The programer programs many functional programs.',
+                           ['the', 'program', 'program', 'mani', 'function', 'program', '.']),
+                          ('It is likely that many like words have liked liking other likes',
+                          ['It', 'is', 'like', 'that', 'mani', 'like', 'word',
+                           'have', 'like', 'like', 'other', 'like']),
+                          ("If you can't avoid it. We'll all use punctuation.",
+                           ['If', 'you', 'ca', "n't", 'avoid', 'it', '.', 'We', "'ll", 'all', 'use', 'punctuat', '.'])])
+def test_tokenize(input_text, answer):
+    # given
+    text = input_text
+
+    # when
+    result = tokenize(text)
+
+    # then
+    expected_result = answer
+    assert result == expected_result
+
+
+@pytest.mark.parametrize('text_input, answer', [('A list of words with stopwords should drop some',
+                                                 ['list', 'word', 'stopword', 'should', 'drop', 'some']),
+                                                ('A second sentence was only more of a test because we need more tests',
+                                                 ['second', 'sentenc', 'wa', 'onli', 'test', 'need', 'test'])])
+@mock.patch('src.util.analyzer.stopwords.words', return_value=['a', 'how', 'becaus', 'i', 'was', 'we',
+                                                               'him', 'was', 'on', 'me', 'more', 'with', 'of', ])
+def test_normalize(stopwords, text_input, answer):
+    #given
+    text_input = text_input
+
+    #when
+    result = normalize(text_input)
+
+    #then
+    expected_result = answer
+    assert result == expected_result


### PR DESCRIPTION
starts working on "Test needed for the current codes #5"

output of tests so far:

Testing started at 2:52 PM ...
\#########\textMining\venv\Scripts\python.exe \################\pycharm\_jb_pytest_runner.py --path /###########/textMining/test/test.py
Launching pytest with arguments ##########

============================= test session starts =============================
platform win32 -- Python 3.7.1, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- \###########\textMining\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: \###########\PycharmProjects\textMining\test
plugins: cov-2.8.1
collecting ... collected 5 items

test.py::test_tokenize[The programer programs many functional programs.-answer0] PASSED [ 20%]
test.py::test_tokenize[It is likely that many like words have liked liking other likes-answer1] PASSED [ 40%]
test.py::test_tokenize[If you can't avoid it. We'll all use punctuation.-answer2] PASSED [ 60%]
test.py::test_normalize[A list of words with stopwords should drop some-answer0] PASSED [ 80%]
test.py::test_normalize[A second sentence was only more of a test because we need more tests-answer1] PASSED [100%]

============================== warnings summary ===============================
\#############\textMining\venv\lib\site-packages\nltk\decorators.py:68
  \#############\textMining\venv\lib\site-packages\nltk\decorators.py:68: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
    regargs, varargs, varkwargs, defaults, formatvalue=lambda value: ""

\#############\textMining\venv\lib\site-packages\nltk\lm\counter.py:15
  \#############\textMining\venv\lib\site-packages\nltk\lm\counter.py:15: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Sequence, defaultdict

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 5 passed, 2 warnings in 0.79s ========================

Process finished with exit code 0


Warning messages are due to deprecated commands in the nltk library and should resolve themselves when ntlk released an update